### PR TITLE
fixed bug with outputpath; added optional filename prefix; add umi.re…

### DIFF
--- a/config/demo_config.ini
+++ b/config/demo_config.ini
@@ -1,7 +1,7 @@
 [PATHS]
 bam_file=
 reference_file=/oicr/data/genomes/homo_sapiens_mc/UCSC/hg19_random/Genomic/bwa/0.7.12/hg19_random.fa
-output_path=/u/iwarikoo/Debarcer2/d_output/
+output_dir=/u/iwarikoo/Debarcer2/d_output/
 prep_file=/u/iwarikoo/Debarcer2/debarcer/config/library_prep_types.ini
 
 [SETTINGS]

--- a/config/sample_config.ini
+++ b/config/sample_config.ini
@@ -2,7 +2,7 @@
 [PATHS]
 bam_file=/some/path/
 reference_file=/some/path/
-output_path=/some/path/
+output_dir=/some/path/
 prep_file=/some/path/
 
 [SETTINGS]

--- a/debarcer/debarcer.py
+++ b/debarcer/debarcer.py
@@ -86,10 +86,8 @@ def preprocess_reads(args):
             prefix = filename
     
     # reheader fastqs and add umi in new fastqs header
-    reheader_fastqs(r1_file=args.read1, r2_file=args.read2, r3_file=args.read3,
-                    output_path=output_path, prepname=args.prepname, prepfile=prepfile)
-	
-
+    reheader_fastqs(args.read1, args.read2, args.read3, outdir, prefix, args.prepname, prepfile)
+	 
 
 def group_umis(args):
 	"""Groups and error-corrects UMIs into families."""

--- a/debarcer/src/preprocess_fastqs.py
+++ b/debarcer/src/preprocess_fastqs.py
@@ -1,5 +1,6 @@
 
 import gzip
+import os
 import sys
 import argparse
 import configparser
@@ -42,9 +43,12 @@ def verify_spacer(reads, umis, spacer_seq):
     return True
 
 
-def reheader_fastqs(r1_file, r2_file, r3_file, output_path, prepname, prepfile):
+def reheader_fastqs(r1_file, r2_file, r3_file, outdir, prefix, prepname, prepfile):
     """
-    (Main) Reheaders fastq files according to specified library prep.
+    (str, str, str, str, str, str, str) -> None
+    Take at least 1 input fastq file (r1_file), and reheader fastq file(s)
+    according to the prename-specified library prep. in prepfile. 
+    Reheadered fastqs are written in outdir and named prefix.umi.reheadered_RN.fastq.gz       
     - removes reads without a valid spacer (if applicable)
     - gzip module is very slow, consider subprocess (at the cost of compatibility)
     """
@@ -67,9 +71,8 @@ def reheader_fastqs(r1_file, r2_file, r3_file, output_path, prepname, prepfile):
     r2 = gzip.open(r2_file, "rt") if num_reads > 1 else None
     r3 = gzip.open(r3_file, "rt") if num_reads > 2 else None
 
-    r1_writer = gzip.open(output_path + "_R1.fastq.gz", "wt")
-    r2_writer = gzip.open(output_path + "_R2.fastq.gz",
-                          "wt") if actual_reads > 1 else None
+    r1_writer = gzip.open(os.path.join(outdir, prefix + ".umi.reheadered_R1.fastq.gz"), "wt")
+    r2_writer = gzip.open(os.path.join(outdir, prefix + ".umi.reheadered_R2.fastq.gz"), "wt") if actual_reads > 1 else None
 
     spacer_len_r1 = 0
     spacer_len_r2 = 0
@@ -202,22 +205,21 @@ if __name__ == '__main__':
 
     # Argument parsing
     parser = argparse.ArgumentParser()
-    parser.add_argument('-r1', '--read1', help='Path to first FASTQ file.', required=True)
-    parser.add_argument('-r2', '--read2', help='Path to second FASTQ file, if necessary.')
-    parser.add_argument('-r3', '--read3', help='Path to third FASTQ file, if necessary.')
-    parser.add_argument('-p',  '--prepname', help='Name of library prep to  use (defined in library_prep_types.ini).', required=True)
-    parser.add_argument('-pf', '--prepfile', help='Path to your library_prep_types.ini file.', required=True)
-    parser.add_argument('-o',  '--output_path', help='Path to write new files to.', required=True)
-
+    parser.add_argument('-r1', '--Read1', dest='read1', help='Path to first FASTQ file.', required=True)
+    parser.add_argument('-r2', '--Read2', dest='read2', help='Path to second FASTQ file, if applicable')
+    parser.add_argument('-r3', '--Read3', dest='read3', help='Path to third FASTQ file, if applicable')
+    parser.add_argument('-p',  '--Prepname', dest='prepname', choices=['HALOPLEX', 'SURESELECT', 'EPIC-DS', 'SIMSENSEQ-PE', 'SIMSENSEQ-SE'],
+                        help='Name of library prep to  use (defined in library_prep_types.ini)', required=True)
+    parser.add_argument('-pf', '--Prepfile', dest='prepfile', help='Path to the library_prep_types.ini file', required=True)
+    parser.add_argument('-o', '--OutDir', dest='outdir', help='Output directory where fastqs are written', required=True)
+    parser.add_argument('-px', '--Prefix', dest= 'prefix', help='Prefix for naming umi-reheradered fastqs. Use Prefix from Read1 if not provided') 
+    
     args = parser.parse_args()
 
-    r1_file = args.read1
-    r2_file = args.read2
-    r3_file = args.read3
-    output_path = args.output_path
-    prepname = args.prepname
-    prepfile = args.prepfile
+    r1_file, r2_file, r3_file = args.read1, args.read2, args.read3
+    outdir, prefix = args.outdir, args.prefix
+    prepname, prepfile = args.prepname, args.prepfile
 
     # Preprocess (reheader fastq files)
-    reheader_fastqs(r1_file, r2_file, r3_file, output_path, prepname, prepfile)
-
+    reheader_fastqs(r1_file, r2_file, r3_file, outdir, prefix, prepname, prepfile)
+    


### PR DESCRIPTION
- fixed bug with output_path
- explicitly check validity of directories and files
- added optional prefix for new reheadered fastqs. use prefix in input file if not provided
- added required output directory. available from the config or command
- create output directory if it doesn't exist on the file system 
- add .umi.RN.fastq.gz to newly generated fastqs